### PR TITLE
added STCGAL tool in pio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 default_envs = n76e003
 
 [env:n76e003]
-platform_packages = platformio/tool-stcgal@^1.110.0
+platform_packages = platformio/tool-stcgal@^1.110.0 ; may not work for linux
 platform = https://github.com/arduino12/platform-intel_mcs51.git
 board = n76e003
 build_flags = -DFOSC_160000

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,6 +2,7 @@
 default_envs = n76e003
 
 [env:n76e003]
+platform_packages = platformio/tool-stcgal@^1.110.0
 platform = https://github.com/arduino12/platform-intel_mcs51.git
 board = n76e003
 build_flags = -DFOSC_160000

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,6 @@ void main(void)
 		P0 ^= 0xff;
 		P1 = ~P1;
 		P30 = !P30;
-		Timer0_Delay1ms(100);
+		Timer0_Delay1ms(1000);
 	}
 }


### PR DESCRIPTION
Your tool works fine on my Windows11, but when I did a clean install I got a compilation error that the "tool-stcgal" was not found. I found my solution [here](https://registry.platformio.org/tools/platformio/tool-stcgal/installation) in the platformio documentation.

However I am unsure if this addition may complicate thing on a Linux installation, but I would not miss the opportunity to help others.

Hans